### PR TITLE
Read README.rst and HISTORY.rst in UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import io
 import os
 import sys
 
@@ -18,10 +19,10 @@ packages = [
     'rfc3986',
 ]
 
-with open('README.rst') as f:
+with io.open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
-with open('HISTORY.rst') as f:
+with io.open('HISTORY.rst', encoding='utf-8') as f:
     history = f.read()
 
 setup(


### PR DESCRIPTION
Since README.rst now contains a snowman character, running setup.py on
Python 3 with a locale encoding different than UTF-8 doesn't work
anymore.

Specify the UTF-8 encoding when reading README.rst and HISTORY.rst in
setup.py to fix this issue (issue #13).