### PR TITLE
Fix some chars (!, =, etc) being treated as not allowed in userinfo of authority

### DIFF
--- a/src/rfc3986/abnf_regexp.py
+++ b/src/rfc3986/abnf_regexp.py
@@ -132,7 +132,9 @@ HOST_RE = HOST_PATTERN = '({0}|{1}|{2})'.format(
     IPv4_RE,
     IP_LITERAL_RE,
 )
-USERINFO_RE = '^[A-Za-z0-9_.~\-%:]+'
+USERINFO_RE = '^([' + UNRESERVED_RE + SUB_DELIMITERS_RE + ':]|%s)+' % (
+    PCT_ENCODED
+)
 PORT_RE = '[0-9]{1,5}'
 
 # ####################

--- a/tests/base.py
+++ b/tests/base.py
@@ -56,6 +56,23 @@ class BaseTestParsesURIs:
         assert uri.path is None
         assert uri.query is None
         assert uri.fragment is None
+        assert uri.userinfo == 'user:pass'
+
+    def test_handles_tricky_userinfo(
+            self, uri_with_port_and_tricky_userinfo):
+        """
+        Test that self.test_class can handle a URI with unusual
+        (non a-z) chars in userinfo.
+        """
+        uri = self.test_class.from_string(uri_with_port_and_tricky_userinfo)
+        assert uri.scheme == 'ssh'
+        # 6 == len('ftp://')
+        assert uri.authority == uri_with_port_and_tricky_userinfo[6:]
+        assert uri.host != uri.authority
+        assert str(uri.port) == '22'
+        assert uri.path is None
+        assert uri.query is None
+        assert uri.fragment is None
         assert uri.userinfo == 'user%20!=:pass'
 
     def test_handles_basic_uri_with_path(self, basic_uri_with_path):
@@ -93,7 +110,7 @@ class BaseTestParsesURIs:
         assert uri.path == '/path/to/resource'
         assert uri.query == 'key=value'
         assert uri.fragment == 'fragment'
-        assert uri.userinfo == 'user%20!=:pass'
+        assert uri.userinfo == 'user:pass'
         assert str(uri.port) == '443'
 
     def test_handles_relative_uri(self, relative_uri):

--- a/tests/base.py
+++ b/tests/base.py
@@ -56,7 +56,7 @@ class BaseTestParsesURIs:
         assert uri.path is None
         assert uri.query is None
         assert uri.fragment is None
-        assert uri.userinfo == 'user:pass'
+        assert uri.userinfo == 'user%20!=:pass'
 
     def test_handles_basic_uri_with_path(self, basic_uri_with_path):
         """Test that self.test_class can handle a URI with a path."""
@@ -93,7 +93,7 @@ class BaseTestParsesURIs:
         assert uri.path == '/path/to/resource'
         assert uri.query == 'key=value'
         assert uri.fragment == 'fragment'
-        assert uri.userinfo == 'user:pass'
+        assert uri.userinfo == 'user%20!=:pass'
         assert str(uri.port) == '443'
 
     def test_handles_relative_uri(self, relative_uri):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def basic_uri_with_port(request):
 
 @pytest.fixture(params=valid_hosts)
 def uri_with_port_and_userinfo(request):
-    return 'ssh://user:pass@%s:22' % request.param
+    return 'ssh://%s@%s:22' % ('user%20!=:pass', request.param)
 
 
 @pytest.fixture(params=valid_hosts)
@@ -92,8 +92,8 @@ def uri_with_path_and_query(request):
 
 @pytest.fixture(params=valid_hosts)
 def uri_with_everything(request):
-    return 'https://user:pass@%s:443/path/to/resource?key=value#fragment' % (
-        request.param)
+    return 'https://%s@%s:443/path/to/resource?key=value#fragment' % (
+        'user%20!=:pass', request.param)
 
 
 @pytest.fixture(params=valid_hosts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,11 @@ def basic_uri_with_port(request):
 
 @pytest.fixture(params=valid_hosts)
 def uri_with_port_and_userinfo(request):
+    return 'ssh://user:pass@%s:22' % request.param
+
+
+@pytest.fixture(params=valid_hosts)
+def uri_with_port_and_tricky_userinfo(request):
     return 'ssh://%s@%s:22' % ('user%20!=:pass', request.param)
 
 
@@ -92,8 +97,8 @@ def uri_with_path_and_query(request):
 
 @pytest.fixture(params=valid_hosts)
 def uri_with_everything(request):
-    return 'https://%s@%s:443/path/to/resource?key=value#fragment' % (
-        'user%20!=:pass', request.param)
+    return 'https://user:pass@%s:443/path/to/resource?key=value#fragment' % (
+        request.param)
 
 
 @pytest.fixture(params=valid_hosts)

--- a/tests/test_parseresult.py
+++ b/tests/test_parseresult.py
@@ -113,7 +113,7 @@ class TestParseResultBytes:
         assert uri.path == b'/path/to/resource'
         assert uri.query == b'key=value'
         assert uri.fragment == b'fragment'
-        assert uri.userinfo == b'user:pass'
+        assert uri.userinfo == b'user%20!=:pass'
         assert uri.port == 443
         assert isinstance(uri.authority, bytes) is True
 

--- a/tests/test_parseresult.py
+++ b/tests/test_parseresult.py
@@ -113,7 +113,7 @@ class TestParseResultBytes:
         assert uri.path == b'/path/to/resource'
         assert uri.query == b'key=value'
         assert uri.fragment == b'fragment'
-        assert uri.userinfo == b'user%20!=:pass'
+        assert uri.userinfo == b'user:pass'
         assert uri.port == 443
         assert isinstance(uri.authority, bytes) is True
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc3986#section-3.2.1

    userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )

Where, according to https://tools.ietf.org/html/rfc3986#section-2.2 ,

    sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
                      / "*" / "+" / "," / ";" / "="

The `sub-delims` and `pct-encoded` sets were missing.

Originated from https://github.com/Lukasa/hyper/pull/331